### PR TITLE
feat(cmake): add option to conditionally build C lcmtypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0060 NEW)
 project(compas_lcmtypes VERSION 0.2.0)
 
+# Option to build the C library and generate C types (default: ON)
+option(LCMTYPES_BUILD_C "Build and install the C library and generate C types" ON)
+
 set(POD_NAME ${PROJECT_NAME})
 
 find_package(lcm REQUIRED)
@@ -20,32 +23,50 @@ if(JAVA_FOUND)
   set(java_args JAVA_SOURCES java_sources)
 endif()
 
-# cmake integration of `lcm-gen`
+# Locate .lcm files
 file(GLOB __lcmtypes "${PROJECT_SOURCE_DIR}/*.lcm")
-lcm_wrap_types(
-  C_EXPORT ${PROJECT_NAME}
-  C_SOURCES c_sources
-  C_HEADERS c_install_headers
-  CPP_HEADERS cpp_install_headers
-  CPP11
-  ${python_args}
-  ${java_args}
-  ${__lcmtypes}
-)
+
+# Conditionally generate types based on the LCMTYPES_BUILD_C option.
+# When the C library is to be built, generate both C and C++ types.
+# Otherwise, do not generate the C types.
+if(LCMTYPES_BUILD_C)
+  lcm_wrap_types(
+    C_EXPORT ${PROJECT_NAME}
+    C_SOURCES c_sources
+    C_HEADERS c_install_headers
+    CPP_HEADERS cpp_install_headers
+    CPP11
+    ${python_args}
+    ${java_args}
+    ${__lcmtypes}
+  )
+else()
+  lcm_wrap_types(
+    CPP_HEADERS cpp_install_headers
+    CPP11
+    ${python_args}
+    ${java_args}
+    ${__lcmtypes}
+  )
+endif()
 
 # ========
 # Build
 # ========
 
-# C library
-include(GenerateExportHeader)
-lcm_add_library(${PROJECT_NAME} C STATIC ${c_sources} ${c_headers})
-generate_export_header(${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME} INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+# Conditionally build the C library if LCMTYPES_BUILD_C is ON
+if(LCMTYPES_BUILD_C)
+  include(GenerateExportHeader)
+  lcm_add_library(${PROJECT_NAME} C STATIC ${c_sources} ${c_headers})
+  generate_export_header(${PROJECT_NAME})
+  target_include_directories(${PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+endif()
 
-# C++ interface (header-only) library
+# Always build the C++ interface (header-only) library
 lcm_add_library(${PROJECT_NAME}-cpp CPP ${cpp_headers})
+# Dummy target to ensure generating the C++ headers
+add_custom_target(force-cpp-lcmtypes ALL DEPENDS ${PROJECT_NAME}-cpp)
 target_include_directories(${PROJECT_NAME}-cpp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
@@ -62,12 +83,25 @@ endif()
 # Install
 # ========
 
-lcm_install_headers(DESTINATION include
-  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h
-  ${c_install_headers}
-  ${cpp_install_headers}
-)
-set(targets ${PROJECT_NAME} ${PROJECT_NAME}-cpp)
+# Conditionally install the C export header and C installation headers
+if(LCMTYPES_BUILD_C)
+  lcm_install_headers(DESTINATION include
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h
+    ${c_install_headers}
+    ${cpp_install_headers}
+  )
+else()
+  # If the C library isn't built, install only the C++ headers
+  lcm_install_headers(DESTINATION include
+    ${cpp_install_headers}
+  )
+endif()
+
+# Export only the targets that were built
+set(targets ${PROJECT_NAME}-cpp)
+if(LCMTYPES_BUILD_C)
+  list(APPEND targets ${PROJECT_NAME})
+endif()
 pods_export_targets("${targets}")
 
 if(Python3_FOUND)


### PR DESCRIPTION
The LCMTYPES_BUILD_C option is added to the CMake configuration to conditionally build C lcmtypes. This option is set to ON by default, allowing the C lcmtypes to be built unless explicitly disabled by the user. This change provides flexibility for users who may not require the C lcmtypes in their projects, allowing them to save build time and have a less polluted build environment (e.g. the include folder).

The feature was tested last Friday (2025-04-11) in the MiniROV raspi and the build process ran without any problems.