### PR TITLE
Python packaging and PyPI publish on release workflow 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Build and Publish
+
+on:
+  release:
+    types: [ created ]
+    
+jobs:
+    build-and-publish:
+      name: Build and Publish to PyPI
+      runs-on: ubuntu-latest
+      permissions:
+        id-token: write
+
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Install uv
+          uses: astral-sh/setup-uv@v5
+
+        - name: Build package
+          run: |
+            uv build
+
+        - name: Publish to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Ignore all directories, and all sub-directories, and it's contents:
 */*
 *.swp
+
+# uv
+uv.lock

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,41 @@
+import subprocess
+from pathlib import Path
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+PACKAGE_NAME = "compas_lcmtypes"
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version, build_data):
+        """Initialize the build hook by generating Python code from LCM files."""
+        # Check if we're doing a pure Python build, and skip generation if so
+        if build_data.get("pure_python", False):
+            return
+
+        # Get the root directory of the project
+        root_dir = Path(self.root)
+
+        # Find all .lcm files in the root directory
+        lcm_files = list(root_dir.glob("*.lcm"))
+
+        # Run lcm-gen for Python on all LCM files
+        lcm_gen_cmd = [
+            "lcm-gen",
+            "--python",
+            "--package-prefix", PACKAGE_NAME,
+            *[str(f) for f in lcm_files]
+        ]
+
+        self.app.display_info(f"Running: {' '.join(lcm_gen_cmd)}")
+        try:
+            subprocess.run(
+                lcm_gen_cmd,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            self.app.display_success("Successfully generated Python code from LCM files")
+        except subprocess.CalledProcessError as e:
+            self.app.display_error(f"Error running lcm-gen: {e}")
+            self.app.display_error(f"stdout: {e.stdout.decode() if e.stdout else ''}")
+            self.app.display_error(f"stderr: {e.stderr.decode() if e.stderr else ''}")
+            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[project]
+name = "compas-lcmtypes"
+version = "0.2.0"
+description = "CoMPAS LCM types"
+requires-python = ">=3.8"
+dependencies = []
+authors = [
+    { name = "CoMPAS Lab" },
+]
+maintainers = [
+    { name = "Kevin Barnard", email = "kbarnard@mbari.org" },
+]
+keywords = ["lcm", "robotics", "communication", "messaging", "compas"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries",
+]
+
+[project.urls]
+Repository = "https://github.com/CoMPASLab/compas_lcmtypes"
+"Issue Tracker" = "https://github.com/CoMPASLab/compas_lcmtypes/issues"
+
+[build-system]
+requires = ["hatchling", "lcm"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+packages = ["compas_lcmtypes"]
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+dependencies = ["lcm"]


### PR DESCRIPTION
This PR adds:
- a `pyproject.toml` and Hatch build hook to facilitate building the Python types package
- a publish workflow that runs the build and publishes the package to PyPI upon release