### PR TITLE
fix: CMakeLists C++ target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 # Conditionally build the C library if LCMTYPES_BUILD_C is ON
 if(LCMTYPES_BUILD_C)
   include(GenerateExportHeader)
-  lcm_add_library(${PROJECT_NAME} C STATIC ${c_sources} ${c_headers})
+  lcm_add_library(${PROJECT_NAME} C STATIC ${c_sources} ${c_install_headers})
   generate_export_header(${PROJECT_NAME})
   target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(LCMTYPES_BUILD_C)
 endif()
 
 # Always build the C++ interface (header-only) library
-lcm_add_library(${PROJECT_NAME}-cpp CPP ${cpp_headers})
+lcm_add_library(${PROJECT_NAME}-cpp CPP ${cpp_install_headers})
 # Dummy target to ensure generating the C++ headers
 add_custom_target(force-cpp-lcmtypes ALL DEPENDS ${PROJECT_NAME}-cpp)
 target_include_directories(${PROJECT_NAME}-cpp INTERFACE


### PR DESCRIPTION
* By using `cpp_install_headers` in `lcm_add_library`, the `compas_lcmtypes-cpp` target will now correctly be associated with the header files that are generated by the `lcm_wrap_types` command.