### PR TITLE
CMakeLists correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,14 +57,14 @@ endif()
 # Conditionally build the C library if LCMTYPES_BUILD_C is ON
 if(LCMTYPES_BUILD_C)
   include(GenerateExportHeader)
-  lcm_add_library(${PROJECT_NAME} C STATIC ${c_sources} ${c_headers})
+  lcm_add_library(${PROJECT_NAME} C STATIC ${c_sources} ${c_install_headers})
   generate_export_header(${PROJECT_NAME})
   target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 endif()
 
 # Always build the C++ interface (header-only) library
-lcm_add_library(${PROJECT_NAME}-cpp CPP ${cpp_headers})
+lcm_add_library(${PROJECT_NAME}-cpp CPP ${cpp_install_headers})
 # Dummy target to ensure generating the C++ headers
 add_custom_target(force-cpp-lcmtypes ALL DEPENDS ${PROJECT_NAME}-cpp)
 target_include_directories(${PROJECT_NAME}-cpp INTERFACE


### PR DESCRIPTION
This pull request updates the `CMakeLists.txt` file to ensure that the correct header files are used for the C and C++ libraries during the build process. The changes replace `c_headers` and `cpp_headers` with `c_install_headers` and `cpp_install_headers`, respectively.

Build process updates:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL60-R67): Updated the `lcm_add_library` calls for the C library to use `c_install_headers` instead of `c_headers`, ensuring the correct headers are included during the build.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL60-R67): Updated the `lcm_add_library` calls for the C++ interface library to use `cpp_install_headers` instead of `cpp_headers`, aligning with the intended header files for installation.